### PR TITLE
Restructure upload path

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ Restaurant data can be loaded with the argument `load` followed by the path to t
 ```shell
 cargo run load path/to/json_file.json
 ```
+
+
+## Production
+1. Make sure that you have `x86_64-unknown-linux-musl` in your rust target chain:
+```
+rustup target add x86_64-unknown-linux-musl
+```
+2. Run the deploy script
+```
+./deploy.sh
+```

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,13 +5,16 @@ function build {
 }
 
 function upload {
-    rsync --info=progress2 ./target/x86_64-unknown-linux-musl/release/smiley_rest_api p8:/var/smiley_rest_api/smiley_rest_api
+    echo "Uploading the binary"
+    rsync -az --info=progress2 ./target/x86_64-unknown-linux-musl/release/smiley_rest_api p8:/var/smiley_rest_api/smiley_rest_api
+    echo "Uploading migrations"
+    rsync -az -r --info=progress2 ./migrations p8:/var/smiley_rest_api/
 
-    ssh p8 sudo -S systemctl restart smiley_rest_api.service
+    ssh p8 'sudo systemctl restart smiley_rest_api.service'
 }
 
 echo "Building the binary"
 build
-echo "Uploading the binary"
+echo "Deploying.."
 upload
 echo "Done with deployment."

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,7 @@ function build {
 }
 
 function upload {
-    rsync --info=progress2 ./target/x86_64-unknown-linux-musl/release/smiley_rest_api p8:/var/smiley_rest_api/target/release/smiley_rest_api
+    rsync --info=progress2 ./target/x86_64-unknown-linux-musl/release/smiley_rest_api p8:/var/smiley_rest_api/smiley_rest_api
 
     ssh p8 sudo -S systemctl restart smiley_rest_api.service
 }


### PR DESCRIPTION
Instead of using the dir 
`/var/smiley_rest_api/target/release/smiley_rest_api`
now use 
`/var/smiley_rest_api/smiley_rest_api`

Also adds instructions on how to deploy.