### PR TITLE
Bulk insert SQL & smiley_restaurant_id TEXT

### DIFF
--- a/migrations/0_initial/up.sql
+++ b/migrations/0_initial/up.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS version_history(
 
 CREATE TABLE IF NOT EXISTS restaurant (
   id INTEGER NOT NULL PRIMARY KEY,
-  smiley_restaurant_id INTEGER NOT NULL,
+  smiley_restaurant_id VARCHAR NOT NULL,
   name VARCHAR NOT NULL,
   address VARCHAR NOT NULL,
   zipcode VARCHAR NOT NULL,

--- a/src/database/append_smiley.rs
+++ b/src/database/append_smiley.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct RestaurantWithSmileyReport {
     pub id: i32,
-    pub smiley_restaurant_id: i32,
+    pub smiley_restaurant_id: String,
     pub name: String,
     pub address: String,
     pub zipcode: String,

--- a/src/database/models.rs
+++ b/src/database/models.rs
@@ -10,7 +10,7 @@ use diesel::dsl::{delete, exists, insert_into, select};
 #[derive(Debug, Clone, PartialEq, Queryable, Serialize)]
 pub struct Restaurant {
     pub id: i32,
-    pub smiley_restaurant_id: i32,
+    pub smiley_restaurant_id: String,
     pub name: String,
     pub address: String,
     pub zipcode: String,
@@ -41,11 +41,11 @@ pub struct Simplerestaurant {
 
 use super::schema::restaurant::dsl::restaurant as res_dsl;
 impl Restaurant {
-    pub fn get_restaurant_references(conn: &SqliteConnection) -> Vec<i32> {
+    pub fn get_restaurant_references(conn: &SqliteConnection) -> Vec<String> {
         use super::schema::restaurant::dsl::smiley_restaurant_id;
         res_dsl
             .select(smiley_restaurant_id)
-            .load::<i32>(conn)
+            .load::<String>(conn)
             .expect("Error fetching ids from database")
     }
 
@@ -72,7 +72,7 @@ impl Restaurant {
         convert_res_smiley_pairs(query).get(0).unwrap().to_owned()
     }
 
-    pub fn get_restaurant_by_smiley_id(smiley_restaurant_id: i32, conn: &SqliteConnection) -> i32 {
+    pub fn get_restaurant_by_smiley_id(smiley_restaurant_id: &str, conn: &SqliteConnection) -> i32 {
         restaurant::table
             .filter(restaurant::smiley_restaurant_id.eq(smiley_restaurant_id))
             .select(restaurant::id)

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -19,7 +19,7 @@ table! {
 table! {
     restaurant (id) {
         id -> Integer,
-        smiley_restaurant_id -> Integer,
+        smiley_restaurant_id -> Text,
         name -> Text,
         address -> Text,
         zipcode -> Text,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,10 @@ extern crate diesel;
 extern crate diesel_migrations;
 
 use crate::utils::data_loader;
-use actix_web::{web::JsonConfig, App, HttpServer};
+use actix_web::{
+    web::{self, JsonConfig},
+    App, HttpServer,
+};
 use dotenv::dotenv;
 use std::env;
 
@@ -40,7 +43,8 @@ async fn main() -> std::io::Result<()> {
     HttpServer::new(move || {
         App::new()
             .data(pool.clone())
-            .data(JsonConfig::default().limit(4096))
+            .data(JsonConfig::default().limit(1_000_000 * 250))
+            .data(web::PayloadConfig::new(1_000_000 * 250))
             .service(services::subscription::subscribe)
             .service(services::subscription::unsubscribe)
             .service(services::restaurant::restaurant)

--- a/src/services/admin.rs
+++ b/src/services/admin.rs
@@ -26,7 +26,7 @@ pub async fn insert_smiley_data(
     if is_localhost(req) {
         data_loader::insert_smiley_data(&req_body, &pool.get().unwrap());
 
-        HttpResponse::Ok().body(req_body)
+        HttpResponse::Ok().finish()
     } else {
         HttpResponse::build(StatusCode::from_u16(404).expect("Failed to create status code"))
             .finish()
@@ -42,7 +42,7 @@ pub async fn update_smiley_data(
     if is_localhost(req) {
         data_loader::update_smiley_data(&req_body, &pool.get().unwrap());
 
-        HttpResponse::Ok().body(req_body)
+        HttpResponse::Ok().finish()
     } else {
         HttpResponse::build(StatusCode::from_u16(404).expect("Failed to create status code"))
             .finish()

--- a/src/tests/response_parser.rs
+++ b/src/tests/response_parser.rs
@@ -16,7 +16,7 @@ pub struct Restaurant {
     pub id: i32,
 
     #[serde(alias = "smiley_restaurant_id")]
-    pub smiley_restaurant_id: i32,
+    pub smiley_restaurant_id: String,
 
     #[serde(alias = "name")]
     pub name: String,
@@ -66,7 +66,7 @@ pub struct Restaurantandsmiley {
     pub id: i32,
 
     #[serde(alias = "smiley_restaurant_id")]
-    pub smiley_restaurant_id: i32,
+    pub smiley_restaurant_id: String,
 
     #[serde(alias = "name")]
     pub name: String,

--- a/src/tests/tests.rs
+++ b/src/tests/tests.rs
@@ -47,9 +47,14 @@ mod tests {
             franchise_name: Some(String::from("abba")),
         };
 
-        let testid = insert_restaurant(&conn, &testres, version.id);
+        let testres2 = map_restaurant_json2insert(&testres, 1);
+
+        let inserts = vec![testres2];
+
+
+        insert_restaurants(&conn, &inserts);
         match schema::restaurant::dsl::restaurant
-            .filter(schema::restaurant::smiley_restaurant_id.eq(42545))
+            .filter(schema::restaurant::smiley_restaurant_id.eq("42545"))
             .filter(schema::restaurant::name.eq_all(testres.name))
             .filter(schema::restaurant::address.eq_all(testres.address))
             .filter(schema::restaurant::zipcode.eq_all(testres.zipcode))
@@ -63,7 +68,6 @@ mod tests {
             Err(_) => panic!("Error in test for insert of test restaurant"),
             Ok(res) => {
                 assert_eq!(res.iter().count(), 1);
-                assert_eq!(res.get(0).unwrap().id, testid)
             }
         }
     }
@@ -94,18 +98,18 @@ mod tests {
         load_test_data(&conn);
         let mut res = models::Restaurant::search_by_lat_lng(55.9, 9.0, 55.2, 10.1, &conn);
         struct Vals {
-            smiley_restaurant_id: i32,
+            smiley_restaurant_id: String,
             cvr: String,
             pnr: String,
         }
-        let excepted = vec![
+        let expected = vec![
             Vals {
-                smiley_restaurant_id: 69908,
+                smiley_restaurant_id: String::from("69908"),
                 cvr: String::from("29367876"),
                 pnr: String::from("1012127266"),
             },
             Vals {
-                smiley_restaurant_id: 710347,
+                smiley_restaurant_id: String::from("710347"),
                 cvr: String::from("38290789"),
                 pnr: String::from("1022046981"),
             },
@@ -117,10 +121,10 @@ mod tests {
         for i in res {
             assert_eq!(
                 i.smiley_restaurant_id,
-                excepted.get(j).unwrap().smiley_restaurant_id
+                expected.get(j).unwrap().smiley_restaurant_id
             );
-            assert_eq!(i.cvr, excepted.get(j).unwrap().cvr);
-            assert_eq!(i.pnr, excepted.get(j).unwrap().pnr);
+            assert_eq!(i.cvr, expected.get(j).unwrap().cvr);
+            assert_eq!(i.pnr, expected.get(j).unwrap().pnr);
             j = j + 1;
         }
     }
@@ -348,7 +352,7 @@ mod tests {
             (
                 Restaurant {
                     id: 1,
-                    smiley_restaurant_id: 1,
+                    smiley_restaurant_id: String::from("1"),
                     name: String::from(""),
                     address: String::from(""),
                     zipcode: String::from(""),
@@ -380,7 +384,7 @@ mod tests {
             (
                 Restaurant {
                     id: 1,
-                    smiley_restaurant_id: 1,
+                    smiley_restaurant_id: String::from("1"),
                     name: String::from(""),
                     address: String::from(""),
                     zipcode: String::from(""),
@@ -412,7 +416,7 @@ mod tests {
             (
                 Restaurant {
                     id: 2,
-                    smiley_restaurant_id: 2,
+                    smiley_restaurant_id: String::from("2"),
                     name: String::from(""),
                     address: String::from(""),
                     zipcode: String::from(""),
@@ -445,7 +449,7 @@ mod tests {
         let expected: Vec<RestaurantWithSmileyReport> = vec![
             RestaurantWithSmileyReport {
                 id: 1,
-                smiley_restaurant_id: 1,
+                smiley_restaurant_id: String::from("1"),
                 name: String::from(""),
                 address: String::from(""),
                 zipcode: String::from(""),
@@ -474,7 +478,7 @@ mod tests {
             },
             RestaurantWithSmileyReport {
                 id: 2,
-                smiley_restaurant_id: 2,
+                smiley_restaurant_id: String::from("2"),
                 name: String::from(""),
                 address: String::from(""),
                 zipcode: String::from(""),

--- a/src/tests/tests.rs
+++ b/src/tests/tests.rs
@@ -47,7 +47,7 @@ mod tests {
             franchise_name: Some(String::from("abba")),
         };
 
-        let testres2 = map_restaurant_json2insert(&testres, 1);
+        let testres2 = map_restaurant_json2insert(&testres, version.id);
 
         let inserts = vec![testres2];
 
@@ -163,7 +163,7 @@ mod tests {
         assert!(resp.status().is_success());
         let resp: response_parser::Restaurantandsmiley = test::read_body_json(resp).await;
         assert_eq!(resp.id, 5);
-        assert_eq!(resp.smiley_restaurant_id, 758030);
+        assert_eq!(resp.smiley_restaurant_id, "758030");
         assert_eq!(resp.cvr, "25431944");
         assert_eq!(resp.pnr, "1008217579");
     }
@@ -191,22 +191,35 @@ mod tests {
                 .unwrap()
         });
 
-        assert_eq!(resp.iter().count(), 3);
-        let first = resp.pop().unwrap();
-        let second = resp.pop().unwrap();
-        let third = resp.pop().unwrap();
+        assert_eq!(resp.len(), 3);
 
-        assert_eq!(first.smiley_restaurant_id, 659918);
-        assert_eq!(first.cvr, "36545860");
-        assert_eq!(first.pnr, "1020169008");
+        let mut first_found: bool = false;
+        let mut second_found: bool = false;
+        let mut third_found: bool = false;
 
-        assert_eq!(second.smiley_restaurant_id, 69908);
-        assert_eq!(second.cvr, "29367876");
-        assert_eq!(second.pnr, "1012127266");
-
-        assert_eq!(third.smiley_restaurant_id, 47738);
-        assert_eq!(third.cvr, "30138929");
-        assert_eq!(third.pnr, "1000765515");
+        for res in resp {
+            match res.smiley_restaurant_id.as_str() {
+                "659918"  => {
+                    assert_eq!(res.cvr, "36545860");
+                    assert_eq!(res.pnr, "1020169008");
+                    first_found = true;
+                }
+                "69908" => {
+                    assert_eq!(res.cvr, "29367876");
+                    assert_eq!(res.pnr, "1012127266");
+                    second_found = true;
+                }
+                "47738" => {
+                    assert_eq!(res.cvr, "30138929");
+                    assert_eq!(res.pnr, "1000765515");
+                    third_found = true;
+                }
+                _ => {} //Ignore the rest
+            }
+        }
+        assert!(first_found);
+        assert!(second_found);
+        assert!(third_found);
     }
     #[actix_rt::test]
     async fn test_restaurant_search_multiple_params() {
@@ -228,7 +241,7 @@ mod tests {
         assert_eq!(resp.iter().count(), 1);
         let resp = resp.get(0).unwrap();
         assert_eq!(resp.id, 4);
-        assert_eq!(resp.smiley_restaurant_id, 717825);
+        assert_eq!(resp.smiley_restaurant_id, "717825");
         assert_eq!(resp.cvr, "31262208");
         assert_eq!(resp.pnr, "1022913332");
     }

--- a/src/tests/tests.rs
+++ b/src/tests/tests.rs
@@ -51,7 +51,6 @@ mod tests {
 
         let inserts = vec![testres2];
 
-
         insert_restaurants(&conn, &inserts);
         match schema::restaurant::dsl::restaurant
             .filter(schema::restaurant::smiley_restaurant_id.eq("42545"))
@@ -199,7 +198,7 @@ mod tests {
 
         for res in resp {
             match res.smiley_restaurant_id.as_str() {
-                "659918"  => {
+                "659918" => {
                     assert_eq!(res.cvr, "36545860");
                     assert_eq!(res.pnr, "1020169008");
                     first_found = true;

--- a/src/tests/utils/data_inserter.rs
+++ b/src/tests/utils/data_inserter.rs
@@ -4,6 +4,7 @@ mod tests {
     use crate::database::models::*;
     use crate::utils::data_inserter;
     use crate::utils::json_parser;
+    use data_inserter::map_restaurant_json2insert;
 
     #[actix_rt::test]
     async fn restaurant_removal() {
@@ -12,11 +13,14 @@ mod tests {
         let restaurant = test_restaurant();
 
         let version = Version::get_from_token(&db_pool.get().unwrap(), "1");
-        let id = data_inserter::insert_restaurant(&db_pool.get().unwrap(), &restaurant, version.id);
+        let mut insertable = map_restaurant_json2insert(&restaurant, version.id);
+
+        let mut ress = vec![insertable];
+        let id = data_inserter::insert_restaurants(&db_pool.get().unwrap(), &ress);
 
         let version2 = Version::get_from_token(&db_pool.get().unwrap(), "2");
         let remove_ids = vec![id];
-        data_inserter::remove_restaurant(&db_pool.get().unwrap(), remove_ids, &version2);
+        //data_inserter::remove_restaurant(&db_pool.get().unwrap(), remove_ids, &version2);
 
         let res_vec = Restaurant::get_all_resturants(&db_pool.get().unwrap());
         let removals = RemovedRestaurant::get_removals_since(&db_pool.get().unwrap(), version.id);
@@ -32,10 +36,16 @@ mod tests {
         let restaurant = test_restaurant();
 
         let version_1 = Version::get_from_token(&db_pool.get().unwrap(), "1");
-        data_inserter::insert_restaurant(&db_pool.get().unwrap(), &restaurant, version_1.id);
+        let mut insertable = map_restaurant_json2insert(&restaurant, version_1.id);
+
+        let mut ress = vec![insertable];
+        data_inserter::insert_restaurants(&db_pool.get().unwrap(), &ress);
 
         let version_2 = Version::get_from_token(&db_pool.get().unwrap(), "2");
-        data_inserter::insert_restaurant(&db_pool.get().unwrap(), &restaurant, version_2.id);
+        insertable = map_restaurant_json2insert(&restaurant, version_1.id);
+
+        ress = vec![insertable];
+        data_inserter::insert_restaurants(&db_pool.get().unwrap(), &ress);
 
         let res_total = Restaurant::get_all_resturants(&db_pool.get().unwrap());
         let res_v1 = Restaurant::get_since_version(&db_pool.get().unwrap(), version_1.id);
@@ -53,7 +63,10 @@ mod tests {
         let mut restaurant = test_restaurant();
 
         let version_1 = Version::get_from_token(&db_pool.get().unwrap(), "1");
-        data_inserter::insert_restaurant(&db_pool.get().unwrap(), &restaurant, version_1.id);
+        let insertable = map_restaurant_json2insert(&restaurant, version_1.id);
+
+        let ress = vec![insertable];
+        data_inserter::insert_restaurants(&db_pool.get().unwrap(), &ress);
 
         restaurant.name = String::from("some other name");
         let version_2 = Version::get_from_token(&db_pool.get().unwrap(), "2");
@@ -72,10 +85,18 @@ mod tests {
         let mut restaurant = test_restaurant();
 
         let version_1 = Version::get_from_token(&db_pool.get().unwrap(), "1");
-        data_inserter::insert_restaurant(&db_pool.get().unwrap(), &restaurant, version_1.id);
+        let mut insertable = map_restaurant_json2insert(&restaurant, version_1.id);
+
+        let mut ress = vec![insertable];
+
+        data_inserter::insert_restaurants(&db_pool.get().unwrap(), &ress);
 
         restaurant.smiley_restaurant_id = String::from("5435345"); // Change id for other restaurant
-        data_inserter::insert_restaurant(&db_pool.get().unwrap(), &restaurant, version_1.id);
+
+        insertable = map_restaurant_json2insert(&restaurant, version_1.id);
+
+        ress = vec![insertable];
+        data_inserter::insert_restaurants(&db_pool.get().unwrap(), &ress);
 
         restaurant.name = String::from("some other name");
         let version_2 = Version::get_from_token(&db_pool.get().unwrap(), "2");

--- a/src/tests/utils/data_inserter.rs
+++ b/src/tests/utils/data_inserter.rs
@@ -13,14 +13,14 @@ mod tests {
         let restaurant = test_restaurant();
 
         let version = Version::get_from_token(&db_pool.get().unwrap(), "1");
-        let mut insertable = map_restaurant_json2insert(&restaurant, version.id);
+        let insertable = map_restaurant_json2insert(&restaurant, version.id);
 
-        let mut ress = vec![insertable];
-        let id = data_inserter::insert_restaurants(&db_pool.get().unwrap(), &ress);
+        let ress = vec![insertable];
+        let id = data_inserter::insert_restaurants(&db_pool.get().unwrap(), &ress)[0].1;
 
         let version2 = Version::get_from_token(&db_pool.get().unwrap(), "2");
         let remove_ids = vec![id];
-        //data_inserter::remove_restaurant(&db_pool.get().unwrap(), remove_ids, &version2);
+        data_inserter::remove_restaurant(&db_pool.get().unwrap(), remove_ids, &version2);
 
         let res_vec = Restaurant::get_all_resturants(&db_pool.get().unwrap());
         let removals = RemovedRestaurant::get_removals_since(&db_pool.get().unwrap(), version.id);
@@ -42,7 +42,7 @@ mod tests {
         data_inserter::insert_restaurants(&db_pool.get().unwrap(), &ress);
 
         let version_2 = Version::get_from_token(&db_pool.get().unwrap(), "2");
-        insertable = map_restaurant_json2insert(&restaurant, version_1.id);
+        insertable = map_restaurant_json2insert(&restaurant, version_2.id);
 
         ress = vec![insertable];
         data_inserter::insert_restaurants(&db_pool.get().unwrap(), &ress);

--- a/src/utils/data_loader.rs
+++ b/src/utils/data_loader.rs
@@ -1,10 +1,14 @@
-use super::json_parser::{DeleteData, JsonRestaurant, JsonSmileyReport};
+use super::{
+    data_inserter::{insert_smileys, map_smileyreport_json2insert, InsertSmileyReport},
+    json_parser::{DeleteData, JsonRestaurant, JsonSmileyReport},
+};
+use crate::database::models::Version;
 use crate::utils::json_parser::RichData;
-use crate::{database::models::Version, services::restaurant};
 use crate::{
     database::schema,
     utils::data_inserter::{
-        insert_restaurant, insert_smileys, remove_restaurant, update_restaurant, update_smileys,
+        insert_restaurants, map_restaurant_json2insert, remove_restaurant, update_restaurant,
+        update_smileys, InsertRestaurant,
     },
 };
 use diesel::{JoinOnDsl, QueryDsl, SqliteConnection};
@@ -12,6 +16,7 @@ use diesel::{JoinOnDsl, QueryDsl, SqliteConnection};
 use diesel::prelude::*;
 
 use crate::database::models::*;
+use std::collections::HashMap;
 
 pub fn load_data_from_file(path: &String, conn: &SqliteConnection) {
     let json = std::fs::read_to_string(path).expect("Failed to read file");
@@ -27,11 +32,31 @@ pub fn insert_smiley_data(json: &String, connection: &SqliteConnection) {
 
     let ver = Version::get_from_token(connection, &read_json.token);
 
-    for res in read_json.data {
-        let resid = insert_restaurant(&connection, &res, ver.id);
+    let restaurants: Vec<InsertRestaurant> = read_json
+        .data
+        .iter()
+        .map(|r| map_restaurant_json2insert(r, ver.id))
+        .collect();
 
-        insert_smileys(&connection, &res.smiley_reports, resid);
+    let id_map: HashMap<_, _> = insert_restaurants(&connection, &restaurants)
+        .into_iter()
+        .collect();
+
+    let mut smiley_reports: Vec<InsertSmileyReport> = Vec::new();
+
+    for res in read_json.data {
+        match id_map.get(&res.smiley_restaurant_id) {
+            Some(value) => {
+                for rep in res.smiley_reports {
+                    smiley_reports.push(map_smileyreport_json2insert(&rep, *value));
+                }
+            }
+            None => {
+                panic!("No match on the data which was just inserted!");
+            }
+        }
     }
+    insert_smileys(&connection, &smiley_reports);
 }
 
 pub fn update_smiley_data(json: &String, connection: &SqliteConnection) {
@@ -66,7 +91,7 @@ pub fn get_data_from_database(conn: &SqliteConnection) -> Vec<JsonRestaurant> {
 pub fn conv_res_smiley_to_jsonres(data: Vec<(Restaurant, SmileyReport)>) -> Vec<JsonRestaurant> {
     // Create a variable
     let mut result = Vec::new();
-    let mut smiley_id = 0;
+    let mut smiley_id = "".to_owned();
 
     // if the joined smiley report tuple is not empty, we add the first restaurant
     if !data.is_empty() {
@@ -74,7 +99,7 @@ pub fn conv_res_smiley_to_jsonres(data: Vec<(Restaurant, SmileyReport)>) -> Vec<
         let joined_smiley_report_tuple = data.get(0).unwrap();
 
         // set smiley id
-        smiley_id = joined_smiley_report_tuple.0.smiley_restaurant_id;
+        smiley_id = joined_smiley_report_tuple.0.smiley_restaurant_id.clone();
 
         // convert the first restaurant  to a JSON restaurant
         let mut first_json_restaurant = restaurant_to_jsonrestaurant(&joined_smiley_report_tuple.0);
@@ -101,7 +126,7 @@ pub fn conv_res_smiley_to_jsonres(data: Vec<(Restaurant, SmileyReport)>) -> Vec<
 
         // if the smiley id does not match the current restaurant, we got a new restaurant
         if smiley_id != current_restaurant.smiley_restaurant_id {
-            smiley_id = current_restaurant.smiley_restaurant_id;
+            smiley_id = current_restaurant.smiley_restaurant_id.clone();
             result.push(restaurant_to_jsonrestaurant(current_restaurant));
         }
 


### PR DESCRIPTION
Bulk inserts the SQL instead of inserting 1-by-1. Has the disadvantage that insert order is not guaranteed. But speeds up the insertion by 2 minutes.

Smiley_restaurant_id is now text. The conversion had no purpose.